### PR TITLE
Fixed media_min_width bug

### DIFF
--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -123,22 +123,29 @@ if (typeof Object.create !== 'function') {
                 }
                 if (options.media_min_width) {
 
-                    var query = '[social-feed-id=' + data.id + '] img.attachment';
-                    var image = $(query);
-                    image.error(function() {
-                        image.hide();
-                    });
-                    image.load(function() {
-                        if (image.width() < options.media_min_width) {
+					var query = '[social-feed-id=' + data.id + '] img.attachment';
+					var image = $(query);
+					
+					// preload the image
+					var height, width = '';
+					var img = new Image();
+					var imgSrc = image.attr("src");
+					
+					$(img).load(function () {
+
+					    if (img.width < options.media_min_width) {
                             image.hide();
                         }
-                    });
-                }
-                //if (lastelement) {
+					    // garbage collect img
+					    delete img;
 
-                //loaded[data.social_network]--;
-                //fireCallback();
-                //}
+					}).error(function () {
+					    // image couldnt be loaded
+					    image.hide();
+					    
+					}).attr({ src: imgSrc });
+
+				}
             }
 
         };


### PR DESCRIPTION
The changes in jquery.socialfeed.js fix an issue, where the resulting width was wrong, because it was already changed by CSS.

Now, the dimensions of the source-image are being used, by creating a new image instance, that is being deleted after getting its dimensions.
