### PR TITLE
Allow Instagram lookup by id. Prefix by &

### DIFF
--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -125,12 +125,12 @@ if (typeof Object.create !== 'function') {
 
 					var query = '[social-feed-id=' + data.id + '] img.attachment';
 					var image = $(query);
-					
+
 					// preload the image
 					var height, width = '';
 					var img = new Image();
 					var imgSrc = image.attr("src");
-					
+
 					$(img).load(function () {
 
 					    if (img.width < options.media_min_width) {
@@ -142,7 +142,7 @@ if (typeof Object.create !== 'function') {
 					}).error(function () {
 					    // image couldnt be loaded
 					    image.hide();
-					    
+
 					}).attr({ src: imgSrc });
 
 				}
@@ -417,6 +417,10 @@ if (typeof Object.create !== 'function') {
                                 url = Feed.instagram.api + 'tags/' + hashtag + '/media/recent/?' + 'client_id=' + options.instagram.client_id + '&' + 'count=' + options.instagram.limit + '&callback=?';
                                 Utility.request(url, Feed.instagram.utility.getImages);
                                 break;
+                            case '&':
+                                var id = account.substr(1);
+                                url = Feed.instagram.api + 'users/' + id  + '/?client_id=' + options.instagram.client_id + '&' + 'count=' + options.instagram.limit + '&callback=?';
+                                Utility.request(url, Feed.instagram.utility.getUsers);
                             default:
                         }
                     },
@@ -430,6 +434,7 @@ if (typeof Object.create !== 'function') {
                             }
                         },
                         getUsers: function(json) {
+                            if( ! jQuery.isArray(json.data)) json.data = [json.data]
                             json.data.forEach(function(user) {
                                 var url = Feed.instagram.api + 'users/' + user.id + '/media/recent/?' + 'client_id=' + options.instagram.client_id + '&' + 'count=' + options.instagram.limit + '&callback=?';
                                 Utility.request(url, Feed.instagram.utility.getImages);


### PR DESCRIPTION
I wanted to show Instagram posts of a single user. However, as it's currently implemented in the plugin, when passing a username it uses the /search api endpoint to retrieve posts.

The search endpoint does not return a single user, rather it returns everything (all users?) that matches your search. See, for example, when searching for Victoria's Secret:

https://api.instagram.com/v1/users/search?q=victoriassecret&client_id=88b4730e0e2c4b2f8a09a6184af2e218

vs

https://api.instagram.com/v1/users/3416684/?client_id=88b4730e0e2c4b2f8a09a6184af2e218

I wanted only the official account's posts, so I implemented a way of getting Instagram posts by id. The way this is implemented is by passing the id prefixed by '&' in the accounts property.

```
instagram: {
    accounts: ['&364682107'],
```

Only the posts of that specific account will be returned.

Please let me know if you can agree on this solution and are willing to merge it within the codebase. I'll gladly submit pull requests to update this code, or to rewrite any documentation that would need updating to reflect this addition.

Thanks, 

--J
