### PR TITLE
Fix: Twitter timestamps were wrong when localized

### DIFF
--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -228,7 +228,7 @@ if (typeof Object.create !== 'function') {
                             var post = {};
                             if (element.id) {
                                 post.id = element.id;
-                                post.dt_create = moment(element.created_at, 'dd MMM DD HH:mm:ss ZZ YYYY');
+                                post.dt_create = moment(element.created_at);
                                 post.author_link = 'http://twitter.com/' + element.user.screen_name;
                                 post.author_picture = element.user.profile_image_url;
                                 post.post_url = post.author_link + '/status/' + element.id_str;


### PR DESCRIPTION
While localization worked for Facebook, all Twitter posts were labeled to be 4 months old.
