### PR TITLE
Change Facebook feed to Graph API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Initialize the social-feed plugin:
         $('.social-feed-container').socialfeed({
                     // FACEBOOK
                     facebook:{
-                        accounts: ['@teslamotors','#teslamotors'],
+                        accounts: ['@teslamotors','!teslamotors'],
                         limit: 2,
                         access_token: 'YOUR_FACEBOOK_ACCESS_TOKEN' // APP_ID|APP_SECRET
                     },

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <div class="container">
             <h1>social-feed.js</h1>
             <hr/>
-            <p>jQuery plugin which displays posts by a username or a hashtag from the popular social networks:
+            <p>jQuery plugin which displays posts by a username (@), hashtag (#) or a facebook page (!) from the popular social networks:
                 <br/><i>Facebook</i>, <i>Instagram</i>, <i>Twitter</i>, <i>Google+</i>, <i>VK</i>.
             </p>
             <hr/>
@@ -29,7 +29,7 @@
     </section>
     <section class="stripe">
         <div class="container field">
-            <input type="text" class="input field-left" value="@elonmusk, #elonmusk" id="query">
+            <input type="text" class="input field-left" value="@teslamotors, !teslamotors" id="query">
             <button class='button field-right' id="button-update"><i class="fa fa-refresh"></i>
             </button>
         </div>

--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -261,12 +261,16 @@ if (typeof Object.create !== 'function') {
                         switch (account[0]) {
                             case '@':
                                 var username = account.substr(1);
-                                request_url = Feed.facebook.graph + 'v1.0/' + username + '/posts?' + limit + query_extention;
+                                var userid = Feed.facebook.utility.getUserId(username);
+                                if (userid !== '') {
+                                    request_url = Feed.facebook.graph + 'v2.3/' + userid + '/posts?' + limit + query_extention;    
+                                }
                                 break;
+                            case '!':
+                                var page = account.substr(1);
+                                request_url = Feed.facebook.graph + 'v2.3/' + page + '/feed?' + limit + query_extention;
                                 break;
                             default:
-                                // search by hashtags is depriciated in API v2.x, so we use here v1.0 explicitly
-                                request_url = Feed.facebook.graph + 'v1.0/search?q=' + account + '&' + limit + query_extention;
                         }
                         Utility.request(request_url, Feed.facebook.utility.getPosts);
                     },

--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -271,6 +271,21 @@ if (typeof Object.create !== 'function') {
                         Utility.request(request_url, Feed.facebook.utility.getPosts);
                     },
                     utility: {
+                        getUserId: function(username) {
+                            var url = 'https://graph.facebook.com/' + username;
+                            var result = '';
+                            $.ajax({
+                                url: url,
+                                async: false,
+                                dataType: 'json'
+                            }).done(function(data) {
+                                result = data.id; 
+                            })
+                            .fail(function (xhr, status, errorThrown) {
+                                result = '';
+                            });
+                            return result;
+                        },
                         prepareAttachment: function(element) {
                             var image_url = element.picture;
                             if (image_url.indexOf('_b.') !== -1) {

--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -263,10 +263,6 @@ if (typeof Object.create !== 'function') {
                                 var username = account.substr(1);
                                 request_url = Feed.facebook.graph + 'v1.0/' + username + '/posts?' + limit + query_extention;
                                 break;
-                            case '#':
-                                var hashtag = account.substr(1);
-                                // search by hashtags is depriciated in API v2.x, so we use here v1.0 explicitly
-                                request_url = Feed.facebook.graph + 'v1.0/search?q=%23' + hashtag + '&' + limit + query_extention;
                                 break;
                             default:
                                 // search by hashtags is depriciated in API v2.x, so we use here v1.0 explicitly


### PR DESCRIPTION
As getting #hashtags are not allowed in Facebook API (even if trying to use deprecated v1.0 
http://thenextweb.com/facebook/2015/04/03/facebook-might-be-shutting-down-access-to-hashtags-in-its-api/), this PR does:
- allow page search (pre-fixed with !) using API v2
- update @username search to use API v2
- remove #hashtag search

I think perhaps even the @username search option should be removed from the project (because it's not bringing any data).
