### PR TITLE
Instagram and/or operator added

### DIFF
--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -105,7 +105,7 @@ if (typeof Object.create !== 'function') {
             this.content.text = Utility.wrapLinks(Utility.shorten(data.message + ' ' + data.description), data.social_network);
             this.content.moderation_passed = (options.moderation) ? options.moderation(this.content) : true;
             this.content.tags = data.tags;
-        		Feed[social_network].posts.push(this);
+            Feed[social_network].posts.push(this);
         }
         SocialFeedPost.prototype = {
             render: function() {
@@ -118,7 +118,7 @@ if (typeof Object.create !== 'function') {
 					return false;
 				    }
                 }
-	            if ($(container).children('[social-feed-id=' + data.id + ']').length !== 0) {
+	        if ($(container).children('[social-feed-id=' + data.id + ']').length !== 0) {
                     return false;
                 }
                 if ($(container).children().length === 0) {
@@ -168,8 +168,8 @@ if (typeof Object.create !== 'function') {
 
 				}
         
-            loaded_post_count++;
-//              fireCallback();
+        loaded_post_count++;
+//          fireCallback();
 
             }
 
@@ -313,7 +313,6 @@ if (typeof Object.create !== 'function') {
                             })
                             .fail(function (xhr, status, errorThrown) {
                                 result = '';
-                                console.log(xhr, status, errorThrown);
                             });
                             return result;
                         },
@@ -348,7 +347,6 @@ if (typeof Object.create !== 'function') {
                                     post.render();
                                 });
                             }
-
                         },
                         unifyPostData: function(element) {
                             var post = {},
@@ -489,6 +487,7 @@ if (typeof Object.create !== 'function') {
                         },
                         unifyPostData: function(element) {
                             var post = {};
+                            
                             post.id = element.id;
                             post.dt_create = moment(element.created_time * 1000);
                             post.author_link = 'http://instagram.com/' + element.user.username;
@@ -503,7 +502,6 @@ if (typeof Object.create !== 'function') {
                             if (options.show_media) {
                                 post.attachment = '<img class="attachment" src="' + element.images.standard_resolution.url + '' + '" />';
                             }
-
                             return post;
                         }
                     }

--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -360,7 +360,7 @@ if (typeof Object.create !== 'function') {
                             post.message = (text) ? text : '';
                             post.description = (element.description) ? element.description : '';
                             post.link = (element.link) ? element.link : 'http://facebook.com/' + element.from.id;
-                            
+
                             if (options.show_media === true) {
                                 if (element.picture) {
                                     var attachment = Feed.facebook.utility.prepareAttachment(element);
@@ -487,7 +487,7 @@ if (typeof Object.create !== 'function') {
                         },
                         unifyPostData: function(element) {
                             var post = {};
-                            
+
                             post.id = element.id;
                             post.dt_create = moment(element.created_time * 1000);
                             post.author_link = 'http://instagram.com/' + element.user.username;

--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -32,7 +32,7 @@ if (typeof Object.create !== 'function') {
         function calculatePostsToLoadCount() {
           social_networks.forEach(function(network) {
             if (options[network]) {
-              if (options[network].accounts) {
+              if (options[network].accounts && options.instagram.operator !== 'AND') {
                 posts_to_load_count += options[network].limit * options[network].accounts.length;
               } else {
                 posts_to_load_count += options[network].limit;
@@ -104,15 +104,21 @@ if (typeof Object.create !== 'function') {
             this.content.dt_create = this.content.dt_create.valueOf();
             this.content.text = Utility.wrapLinks(Utility.shorten(data.message + ' ' + data.description), data.social_network);
             this.content.moderation_passed = (options.moderation) ? options.moderation(this.content) : true;
-
-            Feed[social_network].posts.push(this);
+            this.content.tags = data.tags;
+        		Feed[social_network].posts.push(this);
         }
         SocialFeedPost.prototype = {
             render: function() {
+                if(loaded_post_count < posts_to_load_count) {
                 var rendered_html = Feed.template(this.content);
                 var data = this.content;
-
-                if ($(container).children('[social-feed-id=' + data.id + ']').length !== 0) {
+	            var hashtag = options.instagram.accounts[1].substr(1);
+				if(data.social_network === "instagram" && options.instagram.operator === 'AND') {
+                    if($.inArray(hashtag, data.tags) === -1) {
+					return false;
+				    }
+                }
+	            if ($(container).children('[social-feed-id=' + data.id + ']').length !== 0) {
                     return false;
                 }
                 if ($(container).children().length === 0) {
@@ -162,13 +168,12 @@ if (typeof Object.create !== 'function') {
 
 				}
         
-        loaded_post_count++;
-        if(loaded_post_count == posts_to_load_count) {
-          fireCallback();
-        }
-        
+            loaded_post_count++;
+//              fireCallback();
+
             }
 
+            }
         };
 
         var Feed = {
@@ -308,6 +313,7 @@ if (typeof Object.create !== 'function') {
                             })
                             .fail(function (xhr, status, errorThrown) {
                                 result = '';
+                                console.log(xhr, status, errorThrown);
                             });
                             return result;
                         },
@@ -342,11 +348,11 @@ if (typeof Object.create !== 'function') {
                                     post.render();
                                 });
                             }
+
                         },
                         unifyPostData: function(element) {
                             var post = {},
                                 text = (element.message) ? element.message : element.story;
-
                             post.id = element.id;
                             post.dt_create = moment(element.created_time);
                             post.author_link = 'http://facebook.com/' + element.from.id;
@@ -356,7 +362,7 @@ if (typeof Object.create !== 'function') {
                             post.message = (text) ? text : '';
                             post.description = (element.description) ? element.description : '';
                             post.link = (element.link) ? element.link : 'http://facebook.com/' + element.from.id;
-
+                            
                             if (options.show_media === true) {
                                 if (element.picture) {
                                     var attachment = Feed.facebook.utility.prepareAttachment(element);
@@ -449,9 +455,11 @@ if (typeof Object.create !== 'function') {
                                 Utility.request(url, Feed.instagram.utility.getUsers);
                                 break;
                             case '#':
+                                if(options.instagram.operator === 'OR') {
                                 var hashtag = account.substr(1);
                                 url = Feed.instagram.api + 'tags/' + hashtag + '/media/recent/?' + 'client_id=' + options.instagram.client_id + '&' + 'count=' + options.instagram.limit + '&callback=?';
-                                Utility.request(url, Feed.instagram.utility.getImages);
+                                Utility.request(url, Feed.instagram.utility.getImages); 
+                                }
                                 break;
                             case '&':
                                 var id = account.substr(1);
@@ -471,6 +479,9 @@ if (typeof Object.create !== 'function') {
                         },
                         getUsers: function(json) {
                             if( ! jQuery.isArray(json.data)) json.data = [json.data]
+                            if(options.instagram.operator === 'AND') {
+                                options.instagram.limit = 60;
+                            }
                             json.data.forEach(function(user) {
                                 var url = Feed.instagram.api + 'users/' + user.id + '/media/recent/?' + 'client_id=' + options.instagram.client_id + '&' + 'count=' + options.instagram.limit + '&callback=?';
                                 Utility.request(url, Feed.instagram.utility.getImages);
@@ -478,7 +489,6 @@ if (typeof Object.create !== 'function') {
                         },
                         unifyPostData: function(element) {
                             var post = {};
-
                             post.id = element.id;
                             post.dt_create = moment(element.created_time * 1000);
                             post.author_link = 'http://instagram.com/' + element.user.username;
@@ -487,9 +497,13 @@ if (typeof Object.create !== 'function') {
                             post.message = (element.caption && element.caption) ? element.caption.text : '';
                             post.description = '';
                             post.link = element.link;
+                            if(options.instagram.operator === 'AND') {
+                            post.tags = element.tags;
+                            }
                             if (options.show_media) {
                                 post.attachment = '<img class="attachment" src="' + element.images.standard_resolution.url + '' + '" />';
                             }
+
                             return post;
                         }
                     }
@@ -584,7 +598,7 @@ if (typeof Object.create !== 'function') {
                         }
                     }
                 },
-                blogspot: {
+             	blogspot: {
                     loaded: false,
                     getData: function(account) {
                         var url;


### PR DESCRIPTION
for the setup of instagram in index.html the following line can be added: 

operator: 'AND',  //either write AND or OR for the posts to fulfil either account OR hashtag or to fulfil account AND hashtag

and the script either chooses posts with the named account and hashtag or when operator = OR it just does what it did before.

For questions concerning the changes, just ask.

Best Buochserhorn
