### PR TITLE
Fixed jquery-socialfeed.js to allow jQuery object chaining.

### DIFF
--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -631,13 +631,17 @@ if (typeof Object.create !== 'function') {
                 }
             }
         };
-        // Initialization
-        Feed.init();
-        if (options.update_period) {
-            setInterval(function() {
-                return Feed.init();
-            }, options.update_period);
-        }
+        
+        //make the plugin chainable
+        return this.each(function() {
+            // Initialization
+            Feed.init();
+            if (options.update_period) {
+                setInterval(function() {
+                    return Feed.init();
+                }, options.update_period);
+            }
+        })
     };
 
 })(jQuery);


### PR DESCRIPTION
It now returns $(this).each(), per the accepted standard for jQuery plugins.

See:
http://javascriptplayground.com/blog/2012/04/a-jquery-plugin-with-grunt-qunit/
http://learn.jquery.com/plugins/basic-plugin-creation/#chaining
