### PR TITLE
Remove unneeded trailing comma, which can break this script on some parsers

### DIFF
--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -276,7 +276,7 @@ if (typeof Object.create !== 'function') {
                             }
                         }
                         return post;
-                    },
+                    }
                 }
             },
             facebook: {


### PR DESCRIPTION
This comma also breaks minification of this script with Google Closure Compiler.
