### PR TITLE
Use Twitter id_str instead of id

### DIFF
--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -267,7 +267,7 @@ if (typeof Object.create !== 'function') {
                     unifyPostData: function(element) {
                         var post = {};
                         if (element.id) {
-                            post.id = element.id;
+                            post.id = element.id_str;
                             //prevent a moment.js console warning due to Twitter's poor date format.
                             post.dt_create = moment(new Date(element.created_at));
                             post.author_link = 'http://twitter.com/' + element.user.screen_name;


### PR DESCRIPTION
When I tried to create a Twitter only feed based on social-feed I noticed that the id was wrong. After some research I found a page on [dev.twitter.com](https://dev.twitter.com/overview/api/twitter-ids-json-and-snowflake) where the difference between id and id_str is explained.

It's a simple change but now it's possible to create e.g. like or retweet links.
