### PR TITLE
Make more https compatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ $('.social-feed-container').socialfeed({
     // GENERAL SETTINGS
     length:400,                                     //Integer: For posts with text longer than this length, show an ellipsis.
     show_media:true,                                //Boolean: if false, doesn't display any post images
+    show_https_media_only: false,                   //Boolean: if true, remove any images that are not delivered over https, use to prevent insecure content warnings/errors
     media_min_width: 300,                           //Integer: Only get posts with images larger than this value
     update_period: 5000,                            //Integer: Number of seconds before social-feed will attempt to load new posts.
     template: "bower_components/social-feed/template.html",                         //String: Filename used to get the post template.

--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -14,6 +14,7 @@ if (typeof Object.create !== 'function') {
             plugin_folder: '', // a folder in which the plugin is located (with a slash in the end)
             template: 'template.html', // a path to the template file
             show_media: false, // show images of attachments if available
+            show_https_media_only: false, //set to true to prevent insecure content warnings
             media_min_width: 300,
             length: 500, // maximum length of post message shown
             date_format: 'll',
@@ -141,6 +142,21 @@ if (typeof Object.create !== 'function') {
                     }
 
                 }
+                if (options.show_https_media_only) {
+                    var query = '[social-feed-id=' + data.id + '] img.attachment';
+                    var image = $(query);
+
+                    image.each (function (){
+                        var imgSrc = this.attributes.src.value;
+                        var protocol = imgSrc.split("/");
+
+                        if(protocol[0] !== "https:") {
+                            this.remove();
+                        }
+                    })
+
+                }
+
                 if (options.media_min_width) {
 
                     var query = '[social-feed-id=' + data.id + '] img.attachment';


### PR DESCRIPTION
Needed a way to drop images from facebook that weren't https so that browsers don't generate an insecure/mixed content warning.
Needed to remove hardcode http links, replaced them with just // which will keep the protocol of the host webpage.