### PR TITLE
Support for 140+ tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ $('.social-feed-container').socialfeed({
         limit: 2,                                   //Integer: max number of tweets to load
         consumer_key: 'YOUR_CONSUMER_KEY',          //String: consumer key. make sure to have your app read-only
         consumer_secret: 'YOUR_CONSUMER_SECRET_KEY' //String: consumer secret key. make sure to have your app read-only
+        tweet_mode: 'compatibility'                 //String: change to "extended" to show the whole tweet
      },
 
     // VK

--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -239,7 +239,7 @@ if (typeof Object.create !== 'function') {
                                 {
                                     "id": userid,
                                     "count": options.twitter.limit,
-                                    "tweet_mode": "extended"
+                                    "tweet_mode": typeof options.twitter.tweet_mode === "undefined" ? "compatibility" : options.twitter.tweet_mode
                                 },
                                 Feed.twitter.utility.getPosts,
                                 true // this parameter required
@@ -252,7 +252,7 @@ if (typeof Object.create !== 'function') {
                                 {
                                     "q": hashtag,
                                     "count": options.twitter.limit,
-                                    "tweet_mode": "extended"
+                                    "tweet_mode": typeof options.twitter.tweet_mode === "undefined" ? "compatibility" : options.twitter.tweet_mode
                                 },
                                 function(reply) {
                                     Feed.twitter.utility.getPosts(reply.statuses);

--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -236,7 +236,11 @@ if (typeof Object.create !== 'function') {
                             var userid = account.substr(1);
                             cb.__call(
                                 "statuses_userTimeline",
-                                "id=" + userid + "&count=" + options.twitter.limit,
+                                {
+                                    "id": userid,
+                                    "count": options.twitter.limit,
+                                    "tweet_mode": "extended"
+                                },
                                 Feed.twitter.utility.getPosts,
                                 true // this parameter required
                             );
@@ -245,7 +249,11 @@ if (typeof Object.create !== 'function') {
                             var hashtag = account.substr(1);
                             cb.__call(
                                 "search_tweets",
-                                "q=" + hashtag + "&count=" + options.twitter.limit,
+                                {
+                                    "q": hashtag,
+                                    "count": options.twitter.limit,
+                                    "tweet_mode": "extended"
+                                },
                                 function(reply) {
                                     Feed.twitter.utility.getPosts(reply.statuses);
                                 },
@@ -275,7 +283,7 @@ if (typeof Object.create !== 'function') {
                             post.author_picture = element.user.profile_image_url_https;
                             post.post_url = post.author_link + '/status/' + element.id_str;
                             post.author_name = element.user.name;
-                            post.message = element.text;
+                            post.message = element.full_text.substr(element.display_text_range[0], element.display_text_range[1]);
                             post.description = '';
                             post.link = 'http://twitter.com/' + element.user.screen_name + '/status/' + element.id_str;
 

--- a/js/jquery.socialfeed.js
+++ b/js/jquery.socialfeed.js
@@ -283,7 +283,9 @@ if (typeof Object.create !== 'function') {
                             post.author_picture = element.user.profile_image_url_https;
                             post.post_url = post.author_link + '/status/' + element.id_str;
                             post.author_name = element.user.name;
-                            post.message = element.full_text.substr(element.display_text_range[0], element.display_text_range[1]);
+                            post.message = typeof element.text === "undefined"
+                                ? element.full_text.substr(element.display_text_range[0], element.display_text_range[1])
+                                : element.text;
                             post.description = '';
                             post.link = 'http://twitter.com/' + element.user.screen_name + '/status/' + element.id_str;
 


### PR DESCRIPTION
Some tweets didn't show the attached image. I found that the media didn't show up in the API response. After some research I found the Twitter developers page which [mentions some upcoming changes](https://dev.twitter.com/overview/api/upcoming-changes-to-tweets) to the api. Only the first 140 characters of a tweet are taken into consideration, so when an image is added after those 140 characters it's not added as media in the API response.

This PR solves that problem by adding an option to change the ``tweet_mode``. Just changing the mode to "extended" isn't possible, because the full tweet will be displayed instead of the truncated one.

The result with default settings (``tweet_mode=compatibility``)

<img width="792" alt="screen shot 2017-01-02 at 08 38 32" src="https://cloud.githubusercontent.com/assets/250662/21585741/e06ff364-d0c6-11e6-91a3-eeb552417b33.png">


The result with ``tweet_mode=extended``

<img width="775" alt="screen shot 2017-01-02 at 08 36 29" src="https://cloud.githubusercontent.com/assets/250662/21585720/97676b66-d0c6-11e6-8533-0aa05d3b666f.png">

