### PR TITLE
Instagram API limits FIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $('.social-feed-container').socialfeed({
 
     // INSTAGRAM
     instagram:{
-        accounts: ['@teslamotors','#teslamotors'],  //Array: Specify a list of accounts from which to pull posts
+        accounts: ['@ACCOUNTID'],                   //New Instagram Api limits - Get your ACCOUNTID from: https://codeofaninja.com/tools/find-instagram-user-id
         limit: 2,                                   //Integer: max number of posts to load
         client_id: 'YOUR_INSTAGRAM_CLIENT_ID',       //String: Instagram client id (option if using access token)
         access_token: 'YOUR_INSTAGRAM_ACCESS_TOKEN' //String: Instagram access token

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $('.social-feed-container').socialfeed({
 
     // INSTAGRAM
     instagram:{
-        accounts: ['@ACCOUNTID'],                   //New Instagram Api limits - Get your ACCOUNTID from: https://codeofaninja.com/tools/find-instagram-user-id
+        accounts: ['&ACCOUNTID'],                   //New Instagram Api limits - Get your ACCOUNTID from: https://codeofaninja.com/tools/find-instagram-user-id
         limit: 2,                                   //Integer: max number of posts to load
         client_id: 'YOUR_INSTAGRAM_CLIENT_ID',       //String: Instagram client id (option if using access token)
         access_token: 'YOUR_INSTAGRAM_ACCESS_TOKEN' //String: Instagram access token


### PR DESCRIPTION
Instagram API changes – April 4, 2018

Due to some sudden changes that Instagram has made to their API on April 4th, 2018

User Feeds
It is still possible to display your own Instagram account, however, Instagram has removed the ability to display user feeds from other Instagram accounts which are not your own. You can only display the user feed of the account which is associated with your Access Token, but it is no longer possible to display someone else’s feed using your own Access Token.

Public Comments
It is possible to display comments on your own user feeds, but it is no longer possible to display comments on posts in hashtag or location feeds.

Avatars
It is no longer possible to display the avatars of users in hashtag or location feeds.

SOLUTION
Use https://codeofaninja.com/tools/find-instagram-user-id
to get your ACCOUNTID to use in the account array like '&1234556789'